### PR TITLE
注册服务器web页面点击状态连接时，路径中context-path重复两次，修正改配置

### DIFF
--- a/eureka-registry-ms/src/main/resources/application-peer1.yml
+++ b/eureka-registry-ms/src/main/resources/application-peer1.yml
@@ -13,9 +13,9 @@ eureka:
         port: ${management.port}
         context-path: ${management.context-path}
       health:
-        path: ${management.context-path}/health
-    status-page-url-path: ${management.context-path}/info
-    health-check-url-path: ${management.context-path}/health
+        path: /health
+    status-page-url-path: /info
+    health-check-url-path: /health
   client:
     service-url:
       defaultZone: 'http://eureka2:8762/eureka/'

--- a/eureka-registry-ms/src/main/resources/application-peer2.yml
+++ b/eureka-registry-ms/src/main/resources/application-peer2.yml
@@ -13,9 +13,9 @@ eureka:
         port: ${management.port}
         context-path: ${management.context-path}
       health:
-        path: ${management.context-path}/health
-    status-page-url-path: ${management.context-path}/info
-    health-check-url-path: ${management.context-path}/health
+        path: /health
+    status-page-url-path: /info
+    health-check-url-path: /health
   client:
     service-url:
       defaultZone: 'http://eureka1:8763/eureka/'


### PR DESCRIPTION
发现注册服务器状态连接点开后连接为：http://eureka2:10177/e5da837b-a575-4447-b037-100850226a11/e5da837b-a575-4447-b037-100850226a11/info
阅读配置文件，理解为metadata-map:中的context-path配置后，其相对路径已经设置，后续路径就不需要再添加context-path了。